### PR TITLE
Bugfix/exames complementares

### DIFF
--- a/src/views/ComplementaryTests/ComplementaryTests.js
+++ b/src/views/ComplementaryTests/ComplementaryTests.js
@@ -26,16 +26,6 @@ import { useToast } from 'hooks/toast';
 import { useHistory } from 'react-router-dom';
 import TestComplementaryFormList from './components/TestComplementaryFormList';
 
-// TODO: remover esses códigos que não estamos mais
-// function getExamesPorTipo(exames) {
-//   return exames.reduce((acc, curr) => {
-//     var key = curr.tipo_exame_id;
-//     acc[key] = acc[key] || [];
-//     acc[key].push(curr);
-//     return acc;
-//   }, []);
-// }
-
 function ComplementaryTests() {
   const { patient } = usePatient();
 

--- a/src/views/ComplementaryTests/ComplementaryTests.js
+++ b/src/views/ComplementaryTests/ComplementaryTests.js
@@ -23,15 +23,17 @@ import TestComplementaryList from './components/TestComplementaryList';
 import api from 'services/api';
 import { useToast } from 'hooks/toast';
 import { useHistory } from 'react-router-dom';
+import TestComplementaryFormList from './components/TestComplementaryFormList';
 
-function getExamesPorTipo(exames) {
-  return exames.reduce((acc, curr) => {
-    var key = curr.tipo_exame_id;
-    acc[key] = acc[key] || [];
-    acc[key].push(curr);
-    return acc;
-  }, []);
-}
+// TODO: remover esses códigos que não estamos mais
+// function getExamesPorTipo(exames) {
+//   return exames.reduce((acc, curr) => {
+//     var key = curr.tipo_exame_id;
+//     acc[key] = acc[key] || [];
+//     acc[key].push(curr);
+//     return acc;
+//   }, []);
+// }
 
 function ComplementaryTests() {
   const { patient } = usePatient();
@@ -44,7 +46,7 @@ function ComplementaryTests() {
 
   const [examesComplementares, setExamesComplementares] = useState([]);
 
-  const [examesCompPorTipo, setExamesCompPorTipo] = useState([]);
+  // const [examesCompPorTipo, setExamesCompPorTipo] = useState([]);
 
   const [types, setTypes] = useState([]);
 
@@ -94,9 +96,9 @@ function ComplementaryTests() {
     handleComplementaryTests(id);
   }, [handleComplementaryTests, id]);
 
-  useEffect(() => {
-    setExamesCompPorTipo(getExamesPorTipo(examesComplementares));
-  }, [examesComplementares]);
+  // useEffect(() => {
+  //   setExamesCompPorTipo(getExamesPorTipo(examesComplementares));
+  // }, [examesComplementares]);
 
   const handleSubmit = async values => {
     try {
@@ -169,9 +171,7 @@ function ComplementaryTests() {
               {({ isSubmitting }) => (
                 <Form component={FormControl}>
                   <div className={classes.titleWrapper}>
-                    <Typography variant="h2">
-                      Exames laboratoriais complementares
-                    </Typography>
+                    <Typography variant="h2">Exames complementares</Typography>
                     <Grid
                       className={classes.actionSection}
                       item
@@ -194,13 +194,17 @@ function ComplementaryTests() {
                   {/* TODO: colocar depois do primeiro MVP */}
                   {/* <FormikErroObserver /> */}
 
+                  <TestComplementaryFormList />
+
                   {types &&
                     types.length !== 0 &&
                     types.map((tipo, index) => (
                       <TestComplementaryList
                         descricao={tipo.descricao}
                         key={index}
-                        testes={examesCompPorTipo[tipo.id]}
+                        testes={examesComplementares.filter(
+                          exame => exame.descricao === tipo.descricao,
+                        )}
                       />
                     ))}
                 </Form>

--- a/src/views/ComplementaryTests/ComplementaryTests.js
+++ b/src/views/ComplementaryTests/ComplementaryTests.js
@@ -146,7 +146,7 @@ function ComplementaryTests() {
             { label: 'Meus pacientes', route: '/meus-pacientes' },
             { label: 'Categorias', route: '/categorias' },
             {
-              label: 'Exames laboratoriais complementares',
+              label: 'Exames complementares',
               route: '/categorias/exames-complementares/',
             },
           ]}

--- a/src/views/ComplementaryTests/ComplementaryTests.js
+++ b/src/views/ComplementaryTests/ComplementaryTests.js
@@ -13,6 +13,7 @@ import {
   Typography,
   Grid,
   Button,
+  Card,
 } from '@material-ui/core';
 
 import { Formik, Form } from 'formik';
@@ -189,24 +190,32 @@ function ComplementaryTests() {
                     </Grid>
                   </div>
 
-                  <SelectComplementaryTestType types={types} />
+                  <Grid
+                    className={classes.content}
+                    component={Card}
+                    container
+                    direction="column"
+                    spacing={2}
+                  >
+                    <SelectComplementaryTestType types={types} />
 
-                  {/* TODO: colocar depois do primeiro MVP */}
-                  {/* <FormikErroObserver /> */}
+                    {/* TODO: colocar depois do primeiro MVP */}
+                    {/* <FormikErroObserver /> */}
 
-                  <TestComplementaryFormList />
+                    <TestComplementaryFormList />
 
-                  {types &&
-                    types.length !== 0 &&
-                    types.map((tipo, index) => (
-                      <TestComplementaryList
-                        descricao={tipo.descricao}
-                        key={index}
-                        testes={examesComplementares.filter(
-                          exame => exame.descricao === tipo.descricao,
-                        )}
-                      />
-                    ))}
+                    {types &&
+                      types.length !== 0 &&
+                      types.map((tipo, index) => (
+                        <TestComplementaryList
+                          descricao={tipo.descricao}
+                          key={index}
+                          testes={examesComplementares.filter(
+                            exame => exame.descricao === tipo.descricao,
+                          )}
+                        />
+                      ))}
+                  </Grid>
                 </Form>
               )}
             </Formik>

--- a/src/views/ComplementaryTests/ComplementaryTests.js
+++ b/src/views/ComplementaryTests/ComplementaryTests.js
@@ -4,6 +4,7 @@ import useStyles from './styles';
 
 import {
   CustomBreadcrumbs,
+  NotToShowImg,
   // FormikErroObserver,
 } from 'components';
 
@@ -25,6 +26,11 @@ import api from 'services/api';
 import { useToast } from 'hooks/toast';
 import { useHistory } from 'react-router-dom';
 import TestComplementaryFormList from './components/TestComplementaryFormList';
+
+const initialValues = {
+  newComplementaryTests: [],
+  tipoNewTesteSelected: '',
+};
 
 function ComplementaryTests() {
   const { patient } = usePatient();
@@ -151,15 +157,12 @@ function ComplementaryTests() {
           <div className={classes.formWrapper}>
             <Formik
               enableReinitialize
-              initialValues={{
-                newComplementaryTests: [],
-                tipoNewTesteSelected: '',
-              }}
+              initialValues={initialValues}
               onSubmit={handleSubmit}
               validateOnMount
               validationSchema={schema}
             >
-              {({ isSubmitting }) => (
+              {({ isSubmitting, values }) => (
                 <Form component={FormControl}>
                   <div className={classes.titleWrapper}>
                     <Typography variant="h2">Exames complementares</Typography>
@@ -205,6 +208,13 @@ function ComplementaryTests() {
                           )}
                         />
                       ))}
+
+                    {examesComplementares.length === 0 &&
+                      values.newComplementaryTests.length === 0 && (
+                      <Grid item>
+                        <NotToShowImg label="Nenhum exame foi adicionado" />
+                      </Grid>
+                    )}
                   </Grid>
                 </Form>
               )}

--- a/src/views/ComplementaryTests/components/SelectComplementaryTestType/SelectComplementaryTestType.js
+++ b/src/views/ComplementaryTests/components/SelectComplementaryTestType/SelectComplementaryTestType.js
@@ -51,7 +51,7 @@ const SelectComplementaryTestType = props => {
       <Grid item>
         <FormGroup>
           <FormLabel>
-            <Typography variant="h4">Tipo teste</Typography>
+            <Typography variant="h4">Escolher tipo de exame:</Typography>
           </FormLabel>
           <Grid
             className={classes.actionWrapper}
@@ -60,7 +60,7 @@ const SelectComplementaryTestType = props => {
             <Field
               as={TextField}
               className={classes.textField}
-              label="Tipo teste"
+              label="Escolher"
               name="tipoNewTesteSelected"
               onChange={handleChange}
               select

--- a/src/views/ComplementaryTests/components/SelectComplementaryTestType/SelectComplementaryTestType.js
+++ b/src/views/ComplementaryTests/components/SelectComplementaryTestType/SelectComplementaryTestType.js
@@ -45,8 +45,6 @@ const SelectComplementaryTestType = props => {
       className={classes.root}
       component={Card}
       item
-      md={10}
-      xs={12}
     >
       <Grid item>
         <FormGroup>

--- a/src/views/ComplementaryTests/components/TestComplementaryForm/TestComplementaryForm.js
+++ b/src/views/ComplementaryTests/components/TestComplementaryForm/TestComplementaryForm.js
@@ -30,7 +30,7 @@ const TestComplementaryForm = props => {
       component={Card}
       item
     >
-      <FormLabel className={classes.formLabel}>
+      <div className={classes.formLabel}>
         <Typography variant="h4">{descricao}</Typography>
         <IconButton
           aria-label="delete"
@@ -38,7 +38,7 @@ const TestComplementaryForm = props => {
         >
           <DeleteIcon fontSize="small" />
         </IconButton>
-      </FormLabel>
+      </div>
 
       <Grid
         className={classes.formWraper}

--- a/src/views/ComplementaryTests/components/TestComplementaryForm/TestComplementaryForm.js
+++ b/src/views/ComplementaryTests/components/TestComplementaryForm/TestComplementaryForm.js
@@ -20,7 +20,7 @@ import useStyles from './styles';
 const TestComplementaryForm = props => {
   const classes = useStyles();
 
-  const { index, remove, descricao } = props;
+  const { index, remove } = props;
 
   const { values, handleChange, errors, touched } = useFormikContext();
 
@@ -31,7 +31,7 @@ const TestComplementaryForm = props => {
       item
     >
       <div className={classes.formLabel}>
-        <Typography variant="h4">{descricao}</Typography>
+        <Typography variant="h4">Teste</Typography>
         <IconButton
           aria-label="delete"
           onClick={() => remove(index)}
@@ -76,7 +76,7 @@ const TestComplementaryForm = props => {
                   ? errors.newComplementaryTests[index]?.resultado
                   : null
               }
-              label={descricao}
+              // label={descricao}
               name={`newComplementaryTests.${index}.resultado`}
               onChange={handleChange}
               value={values.newComplementaryTests[index].resultado}
@@ -128,7 +128,7 @@ const TestComplementaryForm = props => {
 
 TestComplementaryForm.propTypes = {
   className: PropTypes.string,
-  descricao: PropTypes.string.isRequired,
+  // descricao: PropTypes.string.isRequired,
   index: PropTypes.number.isRequired,
   remove: PropTypes.func.isRequired,
 };

--- a/src/views/ComplementaryTests/components/TestComplementaryForm/TestComplementaryForm.js
+++ b/src/views/ComplementaryTests/components/TestComplementaryForm/TestComplementaryForm.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 
 import PropTypes from 'prop-types';
 
@@ -62,6 +62,7 @@ const TestComplementaryForm = props => {
               className={classes.field}
               component={TextField}
               name={`newComplementaryTests.${index}.resultado`}
+              type="text"
               variant="outlined"
             />
           </FormGroup>
@@ -82,6 +83,7 @@ const TestComplementaryForm = props => {
               component={TextField}
               name={`newComplementaryTests.${index}.data`}
               type="date"
+              variant="outlined"
             />
           </FormGroup>
         </Grid>
@@ -92,9 +94,8 @@ const TestComplementaryForm = props => {
 
 TestComplementaryForm.propTypes = {
   className: PropTypes.string,
-  // descricao: PropTypes.string.isRequired,
   index: PropTypes.number.isRequired,
   remove: PropTypes.func.isRequired,
 };
 
-export default TestComplementaryForm;
+export default memo(TestComplementaryForm);

--- a/src/views/ComplementaryTests/components/TestComplementaryForm/TestComplementaryForm.js
+++ b/src/views/ComplementaryTests/components/TestComplementaryForm/TestComplementaryForm.js
@@ -7,7 +7,6 @@ import {
   FormGroup,
   FormLabel,
   Typography,
-  TextField,
   Card,
   IconButton,
 } from '@material-ui/core';
@@ -16,13 +15,14 @@ import DeleteIcon from '@material-ui/icons/Delete';
 
 import { Field, useFormikContext } from 'formik';
 import useStyles from './styles';
+import { TextField } from 'formik-material-ui';
 
 const TestComplementaryForm = props => {
   const classes = useStyles();
 
   const { index, remove } = props;
 
-  const { values, handleChange, errors, touched } = useFormikContext();
+  const { values } = useFormikContext();
 
   return (
     <Grid
@@ -31,7 +31,9 @@ const TestComplementaryForm = props => {
       item
     >
       <div className={classes.formLabel}>
-        <Typography variant="h4">Teste</Typography>
+        <Typography variant="h4">
+          {values.newComplementaryTests[index].descricao}
+        </Typography>
         <IconButton
           aria-label="delete"
           onClick={() => remove(index)}
@@ -50,36 +52,16 @@ const TestComplementaryForm = props => {
           className={classes.fieldWraper}
           item
           md={6}
-          sm={12}
+          xs={12}
         >
           <FormGroup>
             <FormLabel>
-              <Typography variant="h4">
-                {values.newComplementaryTests[index].descricao}
-              </Typography>
+              <Typography variant="h4">Resultado</Typography>
             </FormLabel>
             <Field
-              InputLabelProps={{
-                shrink: true,
-              }}
-              as={TextField}
               className={classes.field}
-              error={
-                errors.newComplementaryTests &&
-                touched.newComplementaryTests &&
-                !!errors.newComplementaryTests[index]?.resultado
-              }
-              helperText={
-                errors.newComplementaryTests &&
-                touched.newComplementaryTests &&
-                errors.newComplementaryTests[index]?.resultado
-                  ? errors.newComplementaryTests[index]?.resultado
-                  : null
-              }
-              // label={descricao}
+              component={TextField}
               name={`newComplementaryTests.${index}.resultado`}
-              onChange={handleChange}
-              value={values.newComplementaryTests[index].resultado}
               variant="outlined"
             />
           </FormGroup>
@@ -89,35 +71,17 @@ const TestComplementaryForm = props => {
           className={classes.fieldWraper}
           item
           md={6}
-          sm={12}
+          xs={12}
         >
           <FormGroup>
             <FormLabel>
-              <Typography variant="h4">Data de coleta</Typography>
+              <Typography variant="h4">Data</Typography>
             </FormLabel>
             <Field
-              InputLabelProps={{
-                shrink: true,
-              }}
-              as={TextField}
               className={classes.field}
-              error={
-                errors.newComplementaryTests &&
-                touched.newComplementaryTests &&
-                !!errors.newComplementaryTests[index]?.data
-              }
-              helperText={
-                errors.newComplementaryTests &&
-                touched.newComplementaryTests &&
-                errors.newComplementaryTests[index]?.data
-                  ? errors.newComplementaryTests[index]?.data
-                  : null
-              }
-              label="Data da coleta do teste rápido"
+              component={TextField}
               name={`newComplementaryTests.${index}.data`}
-              onChange={handleChange}
               type="date"
-              value={values.newComplementaryTests[index].data}
             />
           </FormGroup>
         </Grid>

--- a/src/views/ComplementaryTests/components/TestComplementaryForm/styles.js
+++ b/src/views/ComplementaryTests/components/TestComplementaryForm/styles.js
@@ -4,6 +4,7 @@ const useStyles = makeStyles(theme => ({
   root: {
     display: 'flex',
     flexDirection: 'column',
+    marginTop: theme.spacing(2),
     padding: theme.spacing(2),
   },
   formWraper: {

--- a/src/views/ComplementaryTests/components/TestComplementaryFormList/TestComplementaryFormList.js
+++ b/src/views/ComplementaryTests/components/TestComplementaryFormList/TestComplementaryFormList.js
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import { FieldArray, useFormikContext } from 'formik';
+import TestComplementaryForm from '../TestComplementaryForm/TestComplementaryForm';
+
+function TestComplementaryFormList() {
+  const { values } = useFormikContext();
+
+  return (
+    <div>
+      {
+        <FieldArray name="newComplementaryTests">
+          {({ remove }) => (
+            <div>
+              {values.newComplementaryTests &&
+                values.newComplementaryTests.length > 0 &&
+                values.newComplementaryTests
+                  .map((teste, index) => (
+                    <TestComplementaryForm
+                      index={values.newComplementaryTests.indexOf(teste)}
+                      key={index}
+                      remove={remove}
+                    />
+                  ))
+                  .reverse()}
+            </div>
+          )}
+        </FieldArray>
+      }
+    </div>
+  );
+}
+
+export default TestComplementaryFormList;

--- a/src/views/ComplementaryTests/components/TestComplementaryFormList/index.js
+++ b/src/views/ComplementaryTests/components/TestComplementaryFormList/index.js
@@ -1,0 +1,1 @@
+export { default } from './TestComplementaryFormList';

--- a/src/views/ComplementaryTests/components/TestComplementaryList/TestComplementaryList.js
+++ b/src/views/ComplementaryTests/components/TestComplementaryList/TestComplementaryList.js
@@ -5,13 +5,15 @@ import PropTypes from 'prop-types';
 
 import { Card, Grid } from '@material-ui/core';
 import TestComplementatyItem from '../TestComplementatyItem';
-import { useFormikContext, FieldArray } from 'formik';
-import TestComplementaryForm from '../TestComplementaryForm';
 
-const TestComplementaryList = ({ testes, descricao }) => {
+const TestComplementaryList = props => {
   const classes = useStyles();
 
-  const { values } = useFormikContext();
+  const { testes, descricao } = props;
+
+  if (testes.length === 0) {
+    return null
+  }
 
   return (
     <div className={classes.root}>
@@ -29,26 +31,6 @@ const TestComplementaryList = ({ testes, descricao }) => {
               teste={teste}
             />
           ))}
-
-        <FieldArray name="newComplementaryTests">
-          {({ remove }) => (
-            <div>
-              {values.newComplementaryTests &&
-                values.newComplementaryTests.length > 0 &&
-                values.newComplementaryTests
-                  .filter(teste => teste.descricao === descricao)
-                  .map((teste, index) => (
-                    <TestComplementaryForm
-                      descricao={descricao}
-                      index={values.newComplementaryTests.indexOf(teste)}
-                      key={index}
-                      remove={remove}
-                    />
-                  ))
-                  .reverse()}
-            </div>
-          )}
-        </FieldArray>
       </Grid>
     </div>
   );

--- a/src/views/ComplementaryTests/components/TestComplementaryList/TestComplementaryList.js
+++ b/src/views/ComplementaryTests/components/TestComplementaryList/TestComplementaryList.js
@@ -20,8 +20,6 @@ const TestComplementaryList = props => {
       <Grid
         component={Card}
         item
-        md={10}
-        xs={12}
       >
         {testes &&
           testes.map((teste, index) => (

--- a/src/views/ComplementaryTests/components/TestComplementatyItem/TestComplementatyItem.js
+++ b/src/views/ComplementaryTests/components/TestComplementatyItem/TestComplementatyItem.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 
 import PropTypes from 'prop-types';
 
@@ -51,7 +51,8 @@ const TestComplementaryItem = ({ teste, descricao }) => {
         {/* resultado */}
         <Grid
           item
-          sm={6}
+          md={6}
+          xs={12}
         >
           <FormGroup>
             <FormLabel>
@@ -60,7 +61,6 @@ const TestComplementaryItem = ({ teste, descricao }) => {
             <TextField
               as={TextField}
               className={classes.field}
-              label="Resultado"
               type="text"
               value={teste.resultado}
               variant="outlined"
@@ -71,21 +71,19 @@ const TestComplementaryItem = ({ teste, descricao }) => {
         {/* data */}
         <Grid
           item
-          sm={6}
+          md={6}
+          xs={12}
         >
           <FormGroup>
             <FormLabel>
               <Typography variant="h4">Data</Typography>
             </FormLabel>
             <TextField
-              InputLabelProps={{
-                shrink: true,
-              }}
               className={classes.field}
               contentEditable={false}
-              label="Data da coleta do teste rápido"
               type="date"
               value={teste.data}
+              variant="outlined"
             />
           </FormGroup>
         </Grid>
@@ -105,4 +103,4 @@ TestComplementaryItem.propTypes = {
   }).isRequired,
 };
 
-export default TestComplementaryItem;
+export default memo(TestComplementaryItem);

--- a/src/views/ComplementaryTests/styles.js
+++ b/src/views/ComplementaryTests/styles.js
@@ -25,6 +25,10 @@ const useStyles = makeStyles(theme => ({
     width: '200px',
     height: '48px',
   },
+  content: {
+    padding: theme.spacing(2),
+    maxWidth: '864px',
+  },
 }));
 
 export default useStyles;


### PR DESCRIPTION
- [x] Ajustar o nome Exames laboratoriais complementares, dentro da Categoria. Deve ficar apenas "Exames complementares" (esses exames não são laboratoriais)

- [x] Quando não tiver nenhum exame cadastrado, mostrar a imagem padrão com informação de nenhum exame cadastrado.

- [x] Ajustar a lixeira - apenas deletar o formulário quando clicar em cima da lixeira. Atualmente o formulário é deletado em qualquer lugar do header do formulário.

- [x] Ajustar nome dos campos conforme [figma](https://www.figma.com/file/1NBrCq4yx1A85TzvlHW1Gs/Registro-COVID?node-id=682%3A2)