### PR TITLE
#169 remove required in data_inicio_sintomas

### DIFF
--- a/src/views/InitialSymptoms/schema.js
+++ b/src/views/InitialSymptoms/schema.js
@@ -3,7 +3,6 @@ import * as Yup from 'yup';
 const schema = Yup.object().shape({
   data_internacao: Yup.date(),
   data_inicio_sintomas: Yup.date()
-    .required('Campo obrigatório')
     .min('01/01/2020', 'Deve ser posterior ou igual à 01/01/2020')
     .max(
       Yup.ref('data_internacao'),


### PR DESCRIPTION
### Contexto

Na página Sintomas Iniciais da Covid 19 , o campo Data do Início dos Sintomas está constando como campo obrigatório, o qual não deve ser, conforme já é especificado no modelo de dados. Este bug identificado pelo Ambiente de Produção está impossibilitando os coletadores salvarem as informações dos pacientes referente a esta página, com isso deve ser corrigido com urgência.

Critério de Aceite

- [x] Campo **Data do início dos sintomas**, na página **Sintomas Iniciais da Covid 19**, **NÃO OBRIGATÓRIO**.