### PR TITLE
Feature/adjust validation exa lab expecifico

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 # server fake
 dbfake.json
 
+.history
+
 # misc
 .DS_Store
 /.env

--- a/src/errors/EmptyRTPCRError.js
+++ b/src/errors/EmptyRTPCRError.js
@@ -1,0 +1,15 @@
+/**
+ * No Exame RT-PCR não teremos nenhum campo obrigatório, a data da coleta e resultado são os
+ * identificadores deste exame.
+ * Se não tiver nenhuma informação preenchida, o exame não deve ser enviado para o backend.
+ * Esse erro deve ser disparando quando o usuário tentar cadastar um Exame RT-PCR sem nenhum campo
+ * preenchido.
+ */
+class EmptyRTPCRError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'EmptyRTPCRError';
+  }
+}
+
+export default EmptyRTPCRError;

--- a/src/models/specificsTests/SpecificsTestsService.js
+++ b/src/models/specificsTests/SpecificsTestsService.js
@@ -1,0 +1,24 @@
+import api from 'services/api';
+
+export const postSpecificTests = (newsTestes, patientId) => {
+  // sanitizando os dasos de novos testes para o envio
+  const newsTestesSanitized = newsTestes.map(test =>
+    test.tipo_teste === 'RTPCR'
+      ? {
+        data_coleta: test.data_coleta,
+        sitio_tipo_id: test.sitio_tipo,
+        data_resultado: test.data_resultado,
+        rt_pcr_resultado_id: test.rt_pcr_resultado,
+      }
+      : {
+        data_realizacao: test.data_realizacao,
+        resultado: test.resultado === 'true' ? true : false,
+      },
+  );
+
+  const newsTestesPromises = newsTestesSanitized.map(test =>
+    api.post(`/pacientes/${patientId}/exames-laboratoriais`, test),
+  );
+
+  return newsTestesPromises;
+}

--- a/src/views/SpecificsTests/SpecificsTests.js
+++ b/src/views/SpecificsTests/SpecificsTests.js
@@ -21,6 +21,7 @@ import { useToast } from 'hooks/toast';
 import PatientInfo from 'components/PatientInfo';
 import { usePatient } from 'context/PatientContext';
 import TesteFormList from './components/TesteFormList';
+import EmptyRTPCRError from 'errors/EmptyRTPCRError';
 
 // Valores iniciais
 const initialValues = {
@@ -77,6 +78,17 @@ const SpecificsTests = () => {
 
   const handleSubmit = async ({ newsTestes }) => {
     try {
+      // Verificando pre submit
+      newsTestes.forEach(item => {
+        if (
+          item.tipo_teste === 'RTPCR' &&
+          !item.data_coleta &&
+          !item.resultado
+        ) {
+          throw new EmptyRTPCRError('Que mensagem mostrar aqui???');
+        }
+      });
+
       // sanitizando os dasos de novos testes para o envio
       const newsTestesSanitized = newsTestes.map(test =>
         test.tipo_teste === 'RTPCR'
@@ -100,7 +112,7 @@ const SpecificsTests = () => {
       // tentando salvar mas sem nada para enviar.
       if (newsTestesPromises.length === 0) {
         addToast({
-          type: 'warning',
+          type: 'error',
           message: 'Nada para salvar.',
         });
         return;
@@ -116,7 +128,17 @@ const SpecificsTests = () => {
 
       window.location.reload();
     } catch (err) {
-      console.log(err);
+      if (err instanceof EmptyRTPCRError) {
+        addToast({
+          type: 'warning',
+          message: err.message,
+        });
+      } else {
+        addToast({
+          type: 'error',
+          message: 'Algo de errado aconteceu',
+        });
+      }
     }
   };
 

--- a/src/views/SpecificsTests/SpecificsTests.js
+++ b/src/views/SpecificsTests/SpecificsTests.js
@@ -60,6 +60,8 @@ const SpecificsTests = () => {
         setexamesPCR(exames => [...exames, ...exames_pcr]);
         setExamesTesteRapido(exames => [...exames, ...exames_teste_rapido]);
       } catch (err) {
+        // TODO: remover depois
+        console.log(err);
         addToast({
           type: 'error',
           message: 'Algo inesperado aconteceu. Tente novamente.',
@@ -85,7 +87,9 @@ const SpecificsTests = () => {
           !item.data_coleta &&
           !item.resultado
         ) {
-          throw new EmptyRTPCRError('Que mensagem mostrar aqui???');
+          throw new EmptyRTPCRError(
+            'Não foi possível salvar pois campos obrigatórios não foram informados',
+          );
         }
       });
 

--- a/src/views/SpecificsTests/SpecificsTests.js
+++ b/src/views/SpecificsTests/SpecificsTests.js
@@ -60,8 +60,6 @@ const SpecificsTests = () => {
         setexamesPCR(exames => [...exames, ...exames_pcr]);
         setExamesTesteRapido(exames => [...exames, ...exames_teste_rapido]);
       } catch (err) {
-        // TODO: remover depois
-        console.log(err);
         addToast({
           type: 'error',
           message: 'Algo inesperado aconteceu. Tente novamente.',
@@ -82,14 +80,12 @@ const SpecificsTests = () => {
     try {
       // Verificando pre submit
       newsTestes.forEach(item => {
-        if (
-          item.tipo_teste === 'RTPCR' &&
-          !item.data_coleta &&
-          !item.resultado
-        ) {
-          throw new EmptyRTPCRError(
-            'Não foi possível salvar pois campos obrigatórios não foram informados',
-          );
+        if (item.tipo_teste === 'RTPCR') {
+          if (!item.data_coleta && !item.sitio_tipo) {
+            throw new EmptyRTPCRError(
+              'Não foi possível salvar pois campos obrigatórios não foram informados',
+            );
+          }
         }
       });
 

--- a/src/views/SpecificsTests/SpecificsTests.js
+++ b/src/views/SpecificsTests/SpecificsTests.js
@@ -22,6 +22,7 @@ import PatientInfo from 'components/PatientInfo';
 import { usePatient } from 'context/PatientContext';
 import TesteFormList from './components/TesteFormList';
 import EmptyRTPCRError from 'errors/EmptyRTPCRError';
+import { postSpecificTests } from 'models/specificsTests/SpecificsTestsService';
 
 // Valores iniciais
 const initialValues = {
@@ -78,36 +79,7 @@ const SpecificsTests = () => {
 
   const handleSubmit = async ({ newsTestes }) => {
     try {
-      // Verificando pre submit
-      newsTestes.forEach(item => {
-        if (item.tipo_teste === 'RTPCR') {
-          if (!item.data_coleta && !item.sitio_tipo) {
-            throw new EmptyRTPCRError(
-              'Não foi possível salvar pois campos obrigatórios não foram informados',
-            );
-          }
-        }
-      });
-
-      // sanitizando os dasos de novos testes para o envio
-      const newsTestesSanitized = newsTestes.map(test =>
-        test.tipo_teste === 'RTPCR'
-          ? {
-            data_coleta: test.data_coleta,
-            sitio_tipo_id: test.sitio_tipo,
-            data_resultado: test.data_resultado,
-            rt_pcr_resultado_id: test.rt_pcr_resultado,
-          }
-          : {
-            data_realizacao: test.data_realizacao,
-            resultado: test.resultado === 'true' ? true : false,
-          },
-      );
-
-      // criando as promises
-      const newsTestesPromises = newsTestesSanitized.map(test =>
-        api.post(`/pacientes/${id}/exames-laboratoriais`, test),
-      );
+      const newsTestesPromises = postSpecificTests(newsTestes, patient.id);
 
       // tentando salvar mas sem nada para enviar.
       if (newsTestesPromises.length === 0) {
@@ -128,17 +100,10 @@ const SpecificsTests = () => {
 
       window.location.reload();
     } catch (err) {
-      if (err instanceof EmptyRTPCRError) {
-        addToast({
-          type: 'warning',
-          message: err.message,
-        });
-      } else {
-        addToast({
-          type: 'error',
-          message: 'Algo de errado aconteceu',
-        });
-      }
+      addToast({
+        type: 'error',
+        message: 'Algo de errado aconteceu',
+      });
     }
   };
 

--- a/src/views/SpecificsTests/SpecificsTests.js
+++ b/src/views/SpecificsTests/SpecificsTests.js
@@ -167,7 +167,7 @@ const SpecificsTests = () => {
               validateOnMount
               validationSchema={schema}
             >
-              {({ isSubmitting, values }) => (
+              {({ isSubmitting, values, errors }) => (
                 <Form component={FormControl}>
                   <div className={classes.titleWrapper}>
                     <Typography variant="h2">

--- a/src/views/SpecificsTests/SpecificsTests.js
+++ b/src/views/SpecificsTests/SpecificsTests.js
@@ -1,5 +1,4 @@
 import React, { useState, useCallback, useEffect } from 'react';
-
 import useStyles from './styles';
 import { CustomBreadcrumbs, NotToShowImg } from 'components';
 import { useParams, useHistory } from 'react-router-dom';
@@ -21,7 +20,6 @@ import { useToast } from 'hooks/toast';
 import PatientInfo from 'components/PatientInfo';
 import { usePatient } from 'context/PatientContext';
 import TesteFormList from './components/TesteFormList';
-import EmptyRTPCRError from 'errors/EmptyRTPCRError';
 import { postSpecificTests } from 'models/specificsTests/SpecificsTestsService';
 
 // Valores iniciais

--- a/src/views/SpecificsTests/components/SelectTestType/SelectTestType.js
+++ b/src/views/SpecificsTests/components/SelectTestType/SelectTestType.js
@@ -27,7 +27,7 @@ const SelectTestType = () => {
       {
         data_coleta: '',
         data_resultado: '',
-        sitio_tipo: '',
+        sitio_tipo: '6', // tipo default => 'Não informado'
         rt_pcr_resultado: '',
         resultado: '',
         data_realizacao: '',

--- a/src/views/SpecificsTests/components/TesteRTCPRItem/TesteRTCPRItem.js
+++ b/src/views/SpecificsTests/components/TesteRTCPRItem/TesteRTCPRItem.js
@@ -66,7 +66,13 @@ const TesteRTPCRItem = ({ teste }) => {
             Teste RT-PCR
           </Typography>
           <Typography variant="caption">
-            Data da coleta: {teste.data_coleta.split('-').reverse().join('/')}
+            Data da coleta:{' '}
+            {teste.data_coleta
+              ? teste.data_coleta
+                .split('-')
+                .reverse()
+                .join('/')
+              : 'não cadastrada'}
           </Typography>
         </div>
       </AccordionSummary>
@@ -130,9 +136,7 @@ const TesteRTPCRItem = ({ teste }) => {
                 shrink: true,
               }}
               type="date"
-              value={teste.data_resultado
-                ? teste.data_resultado
-                : ''}
+              value={teste.data_resultado ? teste.data_resultado : ''}
             />
           </FormGroup>
         </Grid>

--- a/src/views/SpecificsTests/components/TesteRTPCRForm/TesteRTPCRForm.js
+++ b/src/views/SpecificsTests/components/TesteRTPCRForm/TesteRTPCRForm.js
@@ -70,6 +70,12 @@ const TesteRTPCRForm = props => {
         </IconButton>
       </div>
 
+      <ErrorMessage
+        className={classes.errorMessage}
+        component={Typography}
+        name={`newsTestes.${index}`}
+      />
+
       {/* data_coleta */}
       <Grid
         className={classes.fieldTesteRTPCR}

--- a/src/views/SpecificsTests/components/TesteRTPCRForm/TesteRTPCRForm.js
+++ b/src/views/SpecificsTests/components/TesteRTPCRForm/TesteRTPCRForm.js
@@ -119,6 +119,7 @@ const TesteRTPCRForm = props => {
           >
             {sitiosRTPCR.map(({ id, descricao }) => (
               <FormControlLabel
+                checked={descricao === 'Não informado'}
                 control={<Radio />}
                 key={id}
                 label={descricao}

--- a/src/views/SpecificsTests/components/TesteRTPCRForm/TesteRTPCRForm.js
+++ b/src/views/SpecificsTests/components/TesteRTPCRForm/TesteRTPCRForm.js
@@ -119,7 +119,6 @@ const TesteRTPCRForm = props => {
           >
             {sitiosRTPCR.map(({ id, descricao }) => (
               <FormControlLabel
-                checked={descricao === 'Não informado'}
                 control={<Radio />}
                 key={id}
                 label={descricao}

--- a/src/views/SpecificsTests/components/TesteRTPCRForm/styles.js
+++ b/src/views/SpecificsTests/components/TesteRTPCRForm/styles.js
@@ -7,13 +7,16 @@ const useStyles = makeStyles(theme => ({
     marginTop: theme.spacing(2),
     padding: theme.spacing(2),
   },
-  fieldTesteRTPCR:{
-    marginTop: theme.spacing(2)
+  fieldTesteRTPCR: {
+    marginTop: theme.spacing(2),
   },
   formLabel: {
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
+  },
+  errorMessage: {
+    color:  theme.palette.secondary.main,
   },
 }));
 

--- a/src/views/SpecificsTests/components/TesteRapidoItem/TesteRapidoItem.js
+++ b/src/views/SpecificsTests/components/TesteRapidoItem/TesteRapidoItem.js
@@ -38,10 +38,10 @@ const TesteRapidoItem = ({ teste }) => {
           </Typography>
           <Typography variant="caption">
             Data da coleta:{' '}
-            {teste.data_realizacao
+            {teste.data_realizacao ? (teste.data_realizacao
               .split('-')
               .reverse()
-              .join('/')}
+              .join('/')):('não cadastrada')}
           </Typography>
         </div>
       </AccordionSummary>

--- a/src/views/SpecificsTests/schema.js
+++ b/src/views/SpecificsTests/schema.js
@@ -2,7 +2,7 @@ import * as Yup from 'yup';
 
 function chaveComposta(value) {
   if (value.tipo_teste === 'RTPCR') {
-    return value.data_coleta || value.sitio_tipo;
+    return value.data_resultado || value.rt_pcr_resultado;
   } else {
     return true;
   }
@@ -20,6 +20,8 @@ const schema = Yup.object().shape({
         ),
         // TODO: voltando as coisas aqui para um teste
         data_coleta: Yup.date(),
+        data_resultado: Yup.date(),
+        rt_pcr_resultado: Yup.string(),
         sitio_tipo: Yup.string(),
       })
       .test(

--- a/src/views/SpecificsTests/schema.js
+++ b/src/views/SpecificsTests/schema.js
@@ -4,21 +4,6 @@ const schema = Yup.object().shape({
   newsTestes: Yup.array().of(
     Yup.object().shape({
       tipo_teste: Yup.string(),
-      data_coleta: Yup.string().when('tipo_teste', (tipo_teste, schema) =>
-        tipo_teste === 'RTPCR'
-          ? schema.required('Campo obrigatório')
-          : schema,
-      ),
-      sitio_tipo: Yup.string().when('tipo_teste', (tipo_teste, schema) =>
-        tipo_teste === 'RTPCR'
-          ? schema.required('Campo obrigatório')
-          : schema,
-      ),
-      data_realizacao: Yup.string().when('tipo_teste', (tipo_teste, schema) =>
-        tipo_teste === 'RAPIDO'
-          ? schema.required('Campo obrigatório')
-          : schema,
-      ),
       resultado: Yup.string().when('tipo_teste', (tipo_teste, schema) =>
         tipo_teste === 'RAPIDO'
           ? schema.required('Campo obrigatório')

--- a/src/views/SpecificsTests/schema.js
+++ b/src/views/SpecificsTests/schema.js
@@ -1,15 +1,32 @@
 import * as Yup from 'yup';
 
+function chaveComposta(value) {
+  if (value.tipo_teste === 'RTPCR') {
+    return value.data_coleta || value.sitio_tipo;
+  } else {
+    return true;
+  }
+}
+
 const schema = Yup.object().shape({
   newsTestes: Yup.array().of(
-    Yup.object().shape({
-      tipo_teste: Yup.string(),
-      resultado: Yup.string().when('tipo_teste', (tipo_teste, schema) =>
-        tipo_teste === 'RAPIDO'
-          ? schema.required('Campo obrigatório')
-          : schema,
+    Yup.object()
+      .shape({
+        tipo_teste: Yup.string(),
+        resultado: Yup.string().when('tipo_teste', (tipo_teste, schema) =>
+          tipo_teste === 'RAPIDO'
+            ? schema.required('Campo obrigatório')
+            : schema,
+        ),
+        // TODO: voltando as coisas aqui para um teste
+        data_coleta: Yup.date(),
+        sitio_tipo: Yup.string(),
+      })
+      .test(
+        'chaveComposta',
+        'Não foi possível salvar pois campos obrigatórios não foram informados',
+        chaveComposta,
       ),
-    }),
   ),
 });
 


### PR DESCRIPTION
## Escopo
Ajustar as validações de obrigatoriedade dos campos abaixo:
- **Exame RT-PCR**
  - Sítio da amostra RT-PCR
  - Data de coleta RT-PCR
- **Exame teste Rápido**
  - Data de coleta de teste rápido

No Exame RT-PCR não teremos nenhum campo obrigatório,  a **data do resultado** e **resultado** são os identificadores deste exame > Se não tiver nenhuma informação preenchida, o exame não deve ser enviado para o backend. E ao tentar salvar o formulário, sem estas informações o Front, deve apresentar a seguinte mensagem de erro (Toast): **Não foi possível salvar pois campos obrigatórios não foram informados.**

### Critérios de Aceite
- [x] 1.  **Data e Sítio da amostra RT-PCR - não devem ser campos obrigatórios**
   Dado que na página de Exames Laboratoriais Específicos da COVID-19, RT-PCR
   Quando inclua informações de Resultado e Data do Resultado
   Então ao clicar em salvar Não conste como obrigatório os demais campos de Data da Coleta e Sítio da Amostra
 - [x] 2.  **Data de coleta de Teste Rápido - não deve ser campo obrigatório**
   Dado que na página de Exames Laboratoriais Específicos da COVID-19, Teste Rápido
   Quando inclua informações de Resultado 
   Então ao clicar em salvar Não conste como obrigatório o campo de Data da Coleta de Teste Rápido
- [x] 3.  **Data de resultado e Resultado da amostra RT-PCR -  devem ser campos identificadores**
   Dado que na página de Exames Laboratoriais Específicos da COVID-19, RT-PCR
   Quando Não inclua informações de Resultado e Data do Resultado
   Então ao clicar em salvar, apareça a mensagem de erro: Não foi possível salvar pois campos obrigatórios não foram informados
- [x] 4.  Incluir opção **Não Informado** no campo Sítio da amostra RT-PCR