### PR TITLE
Bugfix/comorbidades#178

### DIFF
--- a/src/components/Forms/ChipTextMany.jsx
+++ b/src/components/Forms/ChipTextMany.jsx
@@ -1,24 +1,23 @@
-import React, { useState } from 'react'
-import PropTypes from 'prop-types'
-import { useFormikContext } from 'formik'
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { useFormikContext } from 'formik';
 import {
   TextField,
   FormGroup,
   Chip,
   FormLabel,
-  Button
-} from '@material-ui/core'
-import Add from '@material-ui/icons/Add'
-import randomIndex from 'helpers/randomIndex'
-
+  Button,
+} from '@material-ui/core';
+import Add from '@material-ui/icons/Add';
+import randomIndex from 'helpers/randomIndex';
 
 const ChipsTexts = ({ name }) => {
-  const { setFieldValue, values } = useFormikContext()
+  const { setFieldValue, values } = useFormikContext();
 
-  const handleRemove = (item) => {
-    const old = values[name] || [item]
-    setFieldValue(name, [...old.filter(value => value !== item)])
-  }
+  const handleRemove = item => {
+    const old = values[name] || [item];
+    setFieldValue(name, [...old.filter(value => value !== item)]);
+  };
 
   return (
     <>
@@ -31,39 +30,38 @@ const ChipsTexts = ({ name }) => {
         />
       ))}
     </>
-  )
-}
+  );
+};
 
 ChipsTexts.propTypes = {
-  name: PropTypes.string.isRequired
-}
+  name: PropTypes.string.isRequired,
+};
 
-const ChipTextMany = ({
-  classes,
-  name,
-  label
-}) => {
-  const {
-    setFieldValue,
-    values
-  } = useFormikContext()
+const ChipTextMany = ({ classes, name, label }) => {
+  const { setFieldValue, values } = useFormikContext();
 
-  const [text, setText] = useState('')
+  const [text, setText] = useState('');
 
   const handleAdd = () => {
-    const old = values[name] || []
+    const old = values[name] || [];
     if (old.find(item => item === text)) {
-      return
+      return;
     }
 
-    setFieldValue(name, [...old, text])
-    setText('')
-  }
+    setFieldValue(name, [...old, text]);
+    setText('');
+  };
 
   return (
     <>
-      <FormGroup className={classes.control} component="fieldset">
-        <FormLabel className={classes.label} component="legend">
+      <FormGroup
+        className={classes.control}
+        component="fieldset"
+      >
+        <FormLabel
+          className={classes.label}
+          component="legend"
+        >
           {label}
         </FormLabel>
 
@@ -71,14 +69,15 @@ const ChipTextMany = ({
           <TextField
             className={classes.textFieldWithButton}
             label={label}
-            value={text}
             onChange={({ target }) => setText(target.value)}
+            value={text}
             variant="filled"
           />
 
           <Button
             className={classes.buttonAdd}
             color="secondary"
+            disabled
             onClick={() => handleAdd()}
             startIcon={<Add />}
             type="button"
@@ -89,17 +88,15 @@ const ChipTextMany = ({
         </div>
       </FormGroup>
 
-      <div className={classes.chipWrapper}>
-        {<ChipsTexts name={name} />}
-      </div>
+      <div className={classes.chipWrapper}>{<ChipsTexts name={name} />}</div>
     </>
-  )
-}
+  );
+};
 
 ChipTextMany.propTypes = {
-  name: PropTypes.string.isRequired,
+  classes: PropTypes.instanceOf(Object).isRequired,
   label: PropTypes.string.isRequired,
-  classes: PropTypes.instanceOf(Object).isRequired
-}
+  name: PropTypes.string.isRequired,
+};
 
-export default ChipTextMany
+export default ChipTextMany;

--- a/src/components/Forms/ChipTextMany.jsx
+++ b/src/components/Forms/ChipTextMany.jsx
@@ -77,7 +77,6 @@ const ChipTextMany = ({ classes, name, label }) => {
           <Button
             className={classes.buttonAdd}
             color="secondary"
-            disabled
             onClick={() => handleAdd()}
             startIcon={<Add />}
             type="button"

--- a/src/models/comorbidades/ComorbidadeModel.js
+++ b/src/models/comorbidades/ComorbidadeModel.js
@@ -53,7 +53,7 @@ const mapCamposComorbidadesTipoDoencas = [
   },
   {
     campoComorbidade: 'doenca_reumatologica',
-    iidTipoDoenca: 4,
+    idTipoDoenca: 4,
     descricao: 'Doença reumatológica / autoimune'
   },
   {

--- a/src/models/comorbidades/ComorbidadeService.js
+++ b/src/models/comorbidades/ComorbidadeService.js
@@ -1,8 +1,8 @@
-import api from 'services/api'
-import ComorbidadeModel from 'models/comorbidades/ComorbidadeModel'
+import api from 'services/api';
+import ComorbidadeModel from 'models/comorbidades/ComorbidadeModel';
 
 /** Funções para validação do formulário */
-const validarCamposBoleanos = (campos) => {
+const validarCamposBoleanos = campos => {
   const camposBooleanos = [
     'diabetes',
     'obesidade',
@@ -22,20 +22,25 @@ const validarCamposBoleanos = (campos) => {
     'doenca_neurologica',
     'tuberculose',
     'gestacao',
-    'puerperio'
-  ]
+    'puerperio',
+  ];
 
-  return camposBooleanos.find(item => campos[item] === true || campos[item] === 'sim')
-}
+  return camposBooleanos.find(
+    item => campos[item] === true || campos[item] === 'sim',
+  );
+};
 
 const validarCamposLista = campos => {
-  const camposListas = ['outras_condicoes', 'medicacoes']
-  return camposListas.find(item => campos[item] && campos[item].length > 0)
-}
+  const camposListas = ['outras_condicoes', 'medicacoes'];
+  return camposListas.find(item => campos[item] && campos[item].length > 0);
+};
 
-export const validarCamposFormularioParaSalvar = (campos) => {
-  return validarCamposBoleanos(campos) !== undefined || validarCamposLista(campos) !== undefined
-}
+export const validarCamposFormularioParaSalvar = campos => {
+  return (
+    validarCamposBoleanos(campos) !== undefined ||
+    validarCamposLista(campos) !== undefined
+  );
+};
 /** *** **/
 
 /** Funções auxiliares para envio e recebimento dos dados do formulário */
@@ -45,122 +50,131 @@ const formatarSimNaoParaBooleano = (dados, toModel) => {
     'transplantado',
     'corticosteroide',
     'gestacao',
-    'puerperio'
-  ]
+    'puerperio',
+  ];
 
   for (let campo of camposConverter) {
     if (!Object.prototype.hasOwnProperty.call(dados, campo)) {
-      continue
+      continue;
     }
 
     if (toModel) {
-      dados[campo] = dados[campo] ? 'sim' : 'nao'
-      continue
+      dados[campo] = dados[campo] ? 'sim' : 'nao';
+      continue;
     }
 
-    dados[campo] = dados[campo] === 'sim'
+    dados[campo] = dados[campo] === 'sim';
   }
 
-  return dados
-}
+  return dados;
+};
 
-const formatarCamposNumericos = (dados) => {
+const formatarCamposNumericos = dados => {
   if (dados.gestacao && dados.gestacao_semanas < 0) {
-    dados.gestacao_semanas = dados.gestacao_semanas < 0
-      ? 0
-      : parseInt(dados.gestacao_semanas)
+    dados.gestacao_semanas =
+      dados.gestacao_semanas < 0 ? 0 : parseInt(dados.gestacao_semanas);
   }
 
   if (dados.puerperio && dados.puerperio_semanas < 0) {
-    dados.puerperio_semanas = dados.puerperio_semanas < 0
-      ? 0
-      : parseInt(dados.puerperio_semanas)
+    dados.puerperio_semanas =
+      dados.puerperio_semanas < 0 ? 0 : parseInt(dados.puerperio_semanas);
   }
 
-  return dados
-}
+  return dados;
+};
 
 const formatarMatrizCheckboxParaMatrizDeIds = (dados, toModel) => {
-  for (let relationship of Object.keys(ComorbidadeModel.modelRelationshipManyToMany)) {
-    if (!dados[relationship] || !Object.prototype.hasOwnProperty.call(dados, relationship)) {
-      continue
+  for (let relationship of Object.keys(
+    ComorbidadeModel.modelRelationshipManyToMany,
+  )) {
+    if (
+      !dados[relationship] ||
+      !Object.prototype.hasOwnProperty.call(dados, relationship)
+    ) {
+      continue;
     }
 
     if (toModel) {
-      dados[relationship] = dados[relationship]
-        .reduce((acc, curr) => {
-          if (acc.length < curr.id) {
-            for (let tamanho = acc.length; tamanho <= curr.id; tamanho++) {
-              acc.push(false)
-            }
+      dados[relationship] = dados[relationship].reduce((acc, curr) => {
+        if (acc.length < curr.id) {
+          for (let tamanho = acc.length; tamanho <= curr.id; tamanho++) {
+            acc.push(false);
           }
+        }
 
-          acc[curr.id] = true
-          return acc;
-        }, [])
+        acc[curr.id] = true;
+        return acc;
+      }, []);
 
-      continue
+      continue;
     }
 
-    dados[relationship] = dados[relationship]
-      .reduce((acc, curr, index) => {
-        if (curr) {
-          acc.push(index)
-        }
-        return acc
-      }, [])
+    dados[relationship] = dados[relationship].reduce((acc, curr, index) => {
+      if (curr) {
+        acc.push(index);
+      }
+      return acc;
+    }, []);
   }
 
-  return dados
-}
+  return dados;
+};
 
-const mapCampoModel = (dados) => {
-  const model = {}
+const mapCampoModel = dados => {
+  const model = {};
   for (let field of Object.keys(ComorbidadeModel.model)) {
-    if (!Object.prototype.hasOwnProperty.call(dados, field)) continue
-    model[field] = dados[field]
+    if (!Object.prototype.hasOwnProperty.call(dados, field)) continue;
+    model[field] = dados[field];
   }
 
   if (model.id === '') {
-    delete model.id
+    delete model.id;
   }
 
-  return model
-}
+  return model;
+};
 
-const definirTiposDoencasParaForm = (dados) => {
-  dados.tipo_doencas = []
-  if (!Object.prototype.hasOwnProperty.call(dados, 'doencas') && dados.doencas.length === 0) {
-    return dados
+const definirTiposDoencasParaForm = dados => {
+  dados.tipo_doencas = [];
+  if (
+    !Object.prototype.hasOwnProperty.call(dados, 'doencas') &&
+    dados.doencas.length === 0
+  ) {
+    return dados;
   }
 
   for (let doenca of dados.doencas) {
-    const tipo = ComorbidadeModel.mapCamposComorbidadesTipoDoencas.find(tipo => tipo.idTipoDoenca === doenca.tipo_doenca_id)
+    const tipo = ComorbidadeModel.mapCamposComorbidadesTipoDoencas.find(
+      tipo => tipo.idTipoDoenca === doenca.tipo_doenca_id,
+    );
     if (tipo && !dados.tipo_doencas.find(d => d.id === tipo.idTipoDoenca)) {
-      dados.tipo_doencas = [...dados.tipo_doencas, { ...tipo, id: tipo.idTipoDoenca }]
+      dados.tipo_doencas = [
+        ...dados.tipo_doencas,
+        { ...tipo, id: tipo.idTipoDoenca },
+      ];
     }
   }
 
-  return dados
-}
+  return dados;
+};
 
-const converterRequisicaoParaModelo = (dados) => {
-  dados = { ...definirTiposDoencasParaForm(dados) }
-  dados = { ...formatarSimNaoParaBooleano(dados, true) }
-  dados = { ...formatarMatrizCheckboxParaMatrizDeIds(dados, true) }
-  return dados
-}
+const converterRequisicaoParaModelo = dados => {
+  dados = { ...definirTiposDoencasParaForm(dados) };
+  dados = { ...formatarSimNaoParaBooleano(dados, true) };
+  dados = { ...formatarMatrizCheckboxParaMatrizDeIds(dados, true) };
+  return dados;
+};
 
-export const submitFormComorbidade = (dados) => {
-  dados = { ...formatarSimNaoParaBooleano(dados) }
-  dados = { ...formatarCamposNumericos(dados) }
-  dados = { ...formatarMatrizCheckboxParaMatrizDeIds(dados) }
-  dados = { ...mapCampoModel(dados) }
-  return api.post(`/pacientes/${dados.paciente_id}/comorbidades`, dados)
-}
+export const submitFormComorbidade = dados => {
+  dados = { ...formatarSimNaoParaBooleano(dados) };
+  dados = { ...formatarCamposNumericos(dados) };
+  dados = { ...formatarMatrizCheckboxParaMatrizDeIds(dados) };
+  dados = { ...mapCampoModel(dados) };
+  return api.post(`/pacientes/${dados.paciente_id}/comorbidades`, dados);
+};
 
 export default {
   submitFormComorbidade,
   validarCamposFormularioParaSalvar,
-  converterRequisicaoParaModelo
-}
+  converterRequisicaoParaModelo,
+};

--- a/src/models/comorbidades/ComorbidadeService.js
+++ b/src/models/comorbidades/ComorbidadeService.js
@@ -26,13 +26,19 @@ const validarCamposBoleanos = campos => {
   ];
 
   return camposBooleanos.find(
-    item => campos[item] === true || campos[item] === 'sim',
+    item =>
+      campos[item] === true || campos[item] === 'sim' || campos[item] === 'nao',
   );
 };
 
 const validarCamposLista = campos => {
-  const camposListas = ['outras_condicoes', 'medicacoes'];
-  return camposListas.find(item => campos[item] && campos[item].length > 0);
+  const camposListas = ['outras_condicoes', 'medicacoes', 'doencas'];
+  return camposListas.find(
+    item =>
+      campos[item] &&
+      campos[item].length > 0 &&
+      campos[item].some(elem => elem === true),
+  );
 };
 
 export const validarCamposFormularioParaSalvar = campos => {

--- a/src/views/Comorbidities/ComorbidadesBreadcrumbs.jsx
+++ b/src/views/Comorbidities/ComorbidadesBreadcrumbs.jsx
@@ -2,16 +2,16 @@ import React from 'react'
 import CustomBreadcrumbs from 'components/CustomBreadcrumbs';
 
 const ComorbidadesBreadcrumbs = () => (
-    <CustomBreadcrumbs
-        links={[
-            { label: 'Meus pacientes', route: '/meus-pacientes' },
-            { label: 'Categorias', route: '/categorias' },
-            {
-                label: 'Comorbidades / Condições clínicas de base',
-                route: '/categorias/comorbidades',
-            },
-        ]}
-    />
+  <CustomBreadcrumbs
+    links={[
+      { label: 'Meus pacientes', route: '/meus-pacientes' },
+      { label: 'Categorias', route: '/categorias' },
+      {
+        label: 'Comorbidades / Condições clínicas de base',
+        route: '/categorias/comorbidades',
+      },
+    ]}
+  />
 )
 
 export default ComorbidadesBreadcrumbs

--- a/src/views/Comorbidities/Form/FieldsForm/InputDoencaAdicionalDetalhe.jsx
+++ b/src/views/Comorbidities/Form/FieldsForm/InputDoencaAdicionalDetalhe.jsx
@@ -1,89 +1,102 @@
-import React, { memo } from 'react'
-import PropTypes from 'prop-types'
-import { Field, useFormikContext } from 'formik'
-import { CheckboxWithLabel } from 'formik-material-ui'
+import React, { memo } from 'react';
+import PropTypes from 'prop-types';
+import { Field, useFormikContext } from 'formik';
+import { CheckboxWithLabel } from 'formik-material-ui';
 import {
   Card,
   CardContent,
   Grid,
   Typography,
-  IconButton
-} from '@material-ui/core'
-import DeleteIcon from '@material-ui/icons/Delete'
-import randomIndex from 'helpers/randomIndex'
+  IconButton,
+} from '@material-ui/core';
+import DeleteIcon from '@material-ui/icons/Delete';
+import randomIndex from 'helpers/randomIndex';
 
-const InputDoencaAdicionalDetalhe = (props) => {
-  const { header, doencas, tipoDoenca } = props
-  const { setFieldValue, values } = useFormikContext()
+const InputDoencaAdicionalDetalhe = props => {
+  const { header, doencas, tipoDoenca } = props;
+  const { setFieldValue, values } = useFormikContext();
 
   const removerDoencas = () => {
-    const old = values.doencas
+    const old = values.doencas;
     const novo = Object.keys(old)
       .filter(o => !doencas.find(d => d.id.toString() === o))
       .reduce((acc, curr) => {
-        acc[curr] = old[curr]
-        return acc
-      }, {})
+        acc[curr] = old[curr];
+        return acc;
+      }, {});
+    setFieldValue('doencas', { ...novo });
+  };
 
-    setFieldValue('doencas', { ...novo })
-  }
-
-  const removerTipoDoenca = (tipoDoenca) => {
-    const tipos = values.tipo_doencas.filter(item => item.id !== tipoDoenca.id)
-    setFieldValue('tipo_doencas', [...tipos])
-    removerDoencas()
-  }
+  const removerTipoDoenca = tipoDoenca => {
+    const tipos = values.tipo_doencas.filter(item => item.id !== tipoDoenca.id);
+    setFieldValue('tipo_doencas', [...tipos]);
+    removerDoencas();
+  };
 
   if (doencas.length === 0) {
-    return <></>
+    return <></>;
   }
 
   return (
     <Card>
       <CardContent>
-        <Grid container spacing={3}>
-          <Grid item xs={12}>
-            <Grid container justify="space-between" alignItems="center">
+        <Grid
+          container
+          spacing={3}
+        >
+          <Grid
+            item
+            xs={12}
+          >
+            <Grid
+              alignItems="center"
+              container
+              justify="space-between"
+            >
               <Grid item>
-                <Typography variant="h4" >
-                  {header}
-                </Typography>
+                <Typography variant="h4">{header}</Typography>
               </Grid>
               <Grid item>
-                <IconButton aria-label="delete" onClick={() => removerTipoDoenca(tipoDoenca)}>
+                <IconButton
+                  aria-label="delete"
+                  onClick={() => removerTipoDoenca(tipoDoenca)}
+                >
                   <DeleteIcon fontSize="small" />
                 </IconButton>
               </Grid>
             </Grid>
           </Grid>
-          <Grid item xs={12}>
-            <Typography variant="h5" >
+          <Grid
+            item
+            xs={12}
+          >
+            <Typography variant="h5">
               Selecione a(s) doença(s) que o paciente apresenta
-            </Typography >
+            </Typography>
           </Grid>
-          <Grid item xs={12}>
-            {doencas.map((doenca) => {
-              const name = `doencas.${doenca.id}`
-              return (
-                <Field
-                  component={CheckboxWithLabel}
-                  type="checkbox"
-                  name={name}
-                  key={randomIndex()}
-                  Label={{ label: doenca.descricao }}
-                />
-              )
-            })}
+          <Grid
+            item
+            xs={12}
+          >
+            {doencas.map(doenca => (
+              <Field
+                component={CheckboxWithLabel}
+                key={randomIndex()}
+                Label={{ label: doenca.descricao }}
+                name={`doencas.${doenca.id}`}
+                type="checkbox"
+              />
+            ))}
           </Grid>
         </Grid>
       </CardContent>
     </Card>
-  )
-}
+  );
+};
 
 InputDoencaAdicionalDetalhe.defaultProps = {
   header: PropTypes.string.isRequired,
-  doencas: PropTypes.array.isRequired
-}
+  doencas: PropTypes.array.isRequired,
+};
 
 export default memo(InputDoencaAdicionalDetalhe);

--- a/src/views/Comorbidities/Form/FormBodyComorbidade.jsx
+++ b/src/views/Comorbidities/Form/FormBodyComorbidade.jsx
@@ -1,24 +1,19 @@
-import React from 'react'
-import {
-  Grid,
-  Paper
-} from '@material-ui/core'
-import {
-  useFormikContext
-} from 'formik'
-import TrueFalseRadioRow from 'components/Forms/TrueFalseRadioRow'
-import InputNumberLabel from 'components/Forms/InputNumberLabel'
-import ChipTextMany from 'components/Forms/ChipTextMany'
-import InputDoencas from 'views/Comorbidities/Form/FieldsForm/InputDoencas'
-import InputDoencasAdicionais from 'views/Comorbidities/Form/FieldsForm/InputDoencasAdicionais'
-import InputDoencasAdicionaisDetalhes from 'views/Comorbidities/Form/FieldsForm/InputDoencasAdicionaisDetalhes'
-import InputOrgaosTransplantados from 'views/Comorbidities/Form/FieldsForm/InputOrgaosTransplantados'
-import InputCorticosteroidesDetalhes from 'views/Comorbidities/Form/FieldsForm/InputCorticosteroidesDetalhes'
-import useStyle from '../styles'
+import React from 'react';
+import { Grid, Paper } from '@material-ui/core';
+import { useFormikContext } from 'formik';
+import TrueFalseRadioRow from 'components/Forms/TrueFalseRadioRow';
+import InputNumberLabel from 'components/Forms/InputNumberLabel';
+import ChipTextMany from 'components/Forms/ChipTextMany';
+import InputDoencas from 'views/Comorbidities/Form/FieldsForm/InputDoencas';
+import InputDoencasAdicionais from 'views/Comorbidities/Form/FieldsForm/InputDoencasAdicionais';
+import InputDoencasAdicionaisDetalhes from 'views/Comorbidities/Form/FieldsForm/InputDoencasAdicionaisDetalhes';
+import InputOrgaosTransplantados from 'views/Comorbidities/Form/FieldsForm/InputOrgaosTransplantados';
+import InputCorticosteroidesDetalhes from 'views/Comorbidities/Form/FieldsForm/InputCorticosteroidesDetalhes';
+import useStyle from '../styles';
 
 const FormBodyComorbidade = () => {
-  const classes = useStyle()
-  const { values } = useFormikContext()
+  const classes = useStyle();
+  const { values } = useFormikContext();
 
   return (
     <>
@@ -30,106 +25,141 @@ const FormBodyComorbidade = () => {
         spacing={2}
         xs={8}
       >
-        <Grid item xs={12}>
+        <Grid
+          item
+          xs={12}
+        >
           <InputDoencas />
         </Grid>
-        <Grid item xs={12}>
+        <Grid
+          item
+          xs={12}
+        >
           <InputDoencasAdicionais />
         </Grid>
-        <Grid item xs={12}>
+        <Grid
+          item
+          xs={12}
+        >
           <InputDoencasAdicionaisDetalhes />
         </Grid>
 
-        <Grid item xs={12}>
+        <Grid
+          item
+          xs={12}
+        >
           <TrueFalseRadioRow
-            name='quimioterapia'
-            label='Quimioterapia'
             classes={classes}
+            label="Quimioterapia"
+            name="quimioterapia"
           />
         </Grid>
-        <Grid item xs={12}>
+        <Grid
+          item
+          xs={12}
+        >
           <TrueFalseRadioRow
-            name='transplantado'
-            label='Transplantado'
             classes={classes}
+            label="Transplantado"
+            name="transplantado"
           />
         </Grid>
         {values.transplantado === 'sim' && (
-          <Grid item xs={12}>
+          <Grid
+            item
+            xs={12}
+          >
             <InputOrgaosTransplantados />
           </Grid>
         )}
 
-        <Grid item xs={12}>
+        <Grid
+          item
+          xs={12}
+        >
           <TrueFalseRadioRow
-            name='corticosteroide'
-            label='Faz uso crônico de corticóides?'
             classes={classes}
+            label="Faz uso crônico de corticóides?"
+            name="corticosteroide"
           />
         </Grid>
 
         {values.corticosteroide === 'sim' && (
-          <Grid item xs={12}>
+          <Grid
+            item
+            xs={12}
+          >
             <InputCorticosteroidesDetalhes classes={classes} />
           </Grid>
         )}
 
-        <Grid item xs={12}>
+        <Grid
+          item
+          xs={12}
+        >
           <TrueFalseRadioRow
-            name="gestacao"
+            classes={classes}
             label="Gestação"
-            classes={classes}
+            name="gestacao"
           />
         </Grid>
-
-
         {values.gestacao === 'sim' && (
-          <Grid item xs={12}>
+          <Grid
+            item
+            xs={12}
+          >
             <InputNumberLabel
+              classes={classes}
+              label="Há quantas semanas?"
               name="gestacao_semanas"
-              label="Há quantas semanas?"
-              classes={classes}
             />
           </Grid>
         )}
-
-
-        <Grid item xs={12}>
+        <Grid
+          item
+          xs={12}
+        >
           <TrueFalseRadioRow
-            name="puerperio"
-            label="Puerpério"
             classes={classes}
+            label="Puerpério"
+            name="puerperio"
           />
         </Grid>
-
         {values.puerperio === 'sim' && (
-          <Grid item xs={12}>
+          <Grid
+            item
+            xs={12}
+          >
             <InputNumberLabel
-              name="puerperio_semanas"
-              label="Há quantas semanas?"
               classes={classes}
+              label="Há quantas semanas?"
+              name="puerperio_semanas"
             />
           </Grid>
         )}
-
-        <Grid item xs={12}>
+        <Grid
+          item
+          xs={12}
+        >
           <ChipTextMany
             classes={classes}
-            name="outras_condicoes"
             label="Outras condições"
+            name="outras_condicoes"
           />
         </Grid>
-
-        <Grid item xs={12}>
+        <Grid
+          item
+          xs={12}
+        >
           <ChipTextMany
             classes={classes}
-            name="medicacoes"
             label="Medicações de uso contínuo"
+            name="medicacoes"
           />
         </Grid>
       </Grid>
     </>
-  )
-}
+  );
+};
 
-export default FormBodyComorbidade
+export default FormBodyComorbidade;

--- a/src/views/Comorbidities/Form/FormComorbidade.jsx
+++ b/src/views/Comorbidities/Form/FormComorbidade.jsx
@@ -1,38 +1,35 @@
 import React from 'react';
-import { useHistory } from 'react-router-dom'
-import { Formik, Form } from 'formik'
-import {
-  FormControl
-} from '@material-ui/core';
-import FormHeaderComorbidade from 'views/Comorbidities/Form/FormHeaderComorbidade'
-import FormBodyComorbidade from 'views/Comorbidities/Form/FormBodyComorbidade'
-import { submitFormComorbidade } from 'models/comorbidades/ComorbidadeService'
+import { useHistory } from 'react-router-dom';
+import { Formik, Form } from 'formik';
+import { FormControl } from '@material-ui/core';
+import FormHeaderComorbidade from 'views/Comorbidities/Form/FormHeaderComorbidade';
+import FormBodyComorbidade from 'views/Comorbidities/Form/FormBodyComorbidade';
+import { submitFormComorbidade } from 'models/comorbidades/ComorbidadeService';
 import validationSchema from 'views/Comorbidities/Form/validationSchema';
 import { useToast } from 'hooks/toast';
 
-
 const FormComorbidade = ({ initValues }) => {
-  const history = useHistory()
-  const { addToast } = useToast()
+  const history = useHistory();
+  const { addToast } = useToast();
 
-  const handleSubmit = async (values) => {
+  const handleSubmit = async values => {
     try {
-      await submitFormComorbidade(values)
+      await submitFormComorbidade(values);
       addToast({
         type: 'success',
         message: 'Dados salvos com sucesso',
-      })
+      });
 
-      history.push('/categorias')
+      history.push('/categorias');
     } catch (e) {
-      console.log(e)
+      console.log(e);
       addToast({
         type: 'error',
         message:
           'Ocorreu um erro ao salvar os dados, por favor tente novamente',
-      })
+      });
     }
-  }
+  };
 
   return (
     <Formik
@@ -47,7 +44,7 @@ const FormComorbidade = ({ initValues }) => {
         <FormBodyComorbidade />
       </Form>
     </Formik>
-  )
-}
+  );
+};
 
 export default FormComorbidade;

--- a/src/views/Comorbidities/Form/FormHeaderComorbidade.jsx
+++ b/src/views/Comorbidities/Form/FormHeaderComorbidade.jsx
@@ -3,7 +3,7 @@ import useStyles from 'views/Comorbidities/styles';
 import { Grid, Typography, Button } from '@material-ui/core';
 import { useFormikContext } from 'formik';
 import PatientInfo from 'components/PatientInfo';
-import { validarCamposFormularioParaSalvar } from 'models/comorbidades/ComorbidadeService';
+// import { validarCamposFormularioParaSalvar } from 'models/comorbidades/ComorbidadeService';
 
 const FormHeaderComorbidade = () => {
   const { isSubmitting, isValid, values } = useFormikContext();
@@ -11,17 +11,7 @@ const FormHeaderComorbidade = () => {
   const classes = useStyles();
 
   useEffect(() => {
-    setValido(
-      !isSubmitting && isValid,
-    );
-    // TODO: remover depois
-    console.log('FormHeaderComorbidade')
-    console.log('isSubmitting: ', isSubmitting);
-    console.log('isValid: ', isValid);
-    console.log(
-      'validarCamposFormularioParaSalvar(values): ',
-      validarCamposFormularioParaSalvar(values),
-    );
+    setValido(!isSubmitting && isValid);
   }, [values, isValid, isSubmitting]);
 
   return (

--- a/src/views/Comorbidities/Form/FormHeaderComorbidade.jsx
+++ b/src/views/Comorbidities/Form/FormHeaderComorbidade.jsx
@@ -1,24 +1,28 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect } from 'react';
 import useStyles from 'views/Comorbidities/styles';
-import {
-  Grid,
-  Typography,
-  Button
-} from '@material-ui/core';
-import { useFormikContext } from 'formik'
+import { Grid, Typography, Button } from '@material-ui/core';
+import { useFormikContext } from 'formik';
 import PatientInfo from 'components/PatientInfo';
-import { validarCamposFormularioParaSalvar } from 'models/comorbidades/ComorbidadeService'
+import { validarCamposFormularioParaSalvar } from 'models/comorbidades/ComorbidadeService';
 
 const FormHeaderComorbidade = () => {
-  const { isSubmitting, isValid, values } = useFormikContext()
-  const [valido, setValido] = useState(false)
+  const { isSubmitting, isValid, values } = useFormikContext();
+  const [valido, setValido] = useState(false);
   const classes = useStyles();
 
   useEffect(() => {
     setValido(
-      !isSubmitting && isValid && validarCamposFormularioParaSalvar(values)
-    )
-  }, [values, isValid, isSubmitting])
+      !isSubmitting && isValid,
+    );
+    // TODO: remover depois
+    console.log('FormHeaderComorbidade')
+    console.log('isSubmitting: ', isSubmitting);
+    console.log('isValid: ', isValid);
+    console.log(
+      'validarCamposFormularioParaSalvar(values): ',
+      validarCamposFormularioParaSalvar(values),
+    );
+  }, [values, isValid, isSubmitting]);
 
   return (
     <>
@@ -57,7 +61,7 @@ const FormHeaderComorbidade = () => {
         </Grid>
       </Grid>
     </>
-  )
-}
+  );
+};
 
-export default FormHeaderComorbidade
+export default FormHeaderComorbidade;

--- a/src/views/Comorbidities/Form/FormHeaderComorbidade.jsx
+++ b/src/views/Comorbidities/Form/FormHeaderComorbidade.jsx
@@ -3,7 +3,7 @@ import useStyles from 'views/Comorbidities/styles';
 import { Grid, Typography, Button } from '@material-ui/core';
 import { useFormikContext } from 'formik';
 import PatientInfo from 'components/PatientInfo';
-// import { validarCamposFormularioParaSalvar } from 'models/comorbidades/ComorbidadeService';
+import { validarCamposFormularioParaSalvar } from 'models/comorbidades/ComorbidadeService';
 
 const FormHeaderComorbidade = () => {
   const { isSubmitting, isValid, values } = useFormikContext();
@@ -11,7 +11,9 @@ const FormHeaderComorbidade = () => {
   const classes = useStyles();
 
   useEffect(() => {
-    setValido(!isSubmitting && isValid);
+    setValido(
+      !isSubmitting && isValid && validarCamposFormularioParaSalvar(values),
+    );
   }, [values, isValid, isSubmitting]);
 
   return (


### PR DESCRIPTION
## Contexto

No ambiente de produção, foi constatado que ao tentar salvar outras doenças que o paciente apresenta, e não tendo selecionado umas das cinco opções de doenças do campo Selecione as doenças que o paciente apresenta, o botão Salvar fica desabilitado, impedindo o salvamento.
E ao selecionar uma desta cinco doenças, o botão salvar fica habilitado, porém surge a seguinte mensagem de erro (toast): **Ocorreu um erro ao salvar os dados, por favor tente novamente.**

## Escopo

Na página, comorbidades, verificar o bug que está ocorrendo no salvamento das informações. É necessário que a página permita salvar, mediante qualquer opção de doença que seja selecionada, e ainda mediante campos não preenchidos.

## Critério de Aceite

- [x] Página comorbidades permite salvamento mediante qualquer preenchimento de campo